### PR TITLE
Fix plugin activation error.

### DIFF
--- a/wp-spider-cache.php
+++ b/wp-spider-cache.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Plugin Name: WP Spider Cache
  * Plugin URI:  https://wordpress.org/plugins/wp-spider-cache/


### PR DESCRIPTION
WordPress complains that “The plugin does not have a valid header” if
there’s a space between the opening php tag and the comment block
containing the plugin’s info. Fussy little buddy!
