### PR TITLE
Bumping asset version to ready a SVN deploy

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -87,8 +87,13 @@ http://github.com/stuttter/wp-spider-cache
 
 == Changelog ==
 
+= 2.2.0 =
+* Refactoring throughout
+* Adding caps
+* Cache exempt cookie
+
 = 2.1.1 =
-* Saniity checks for Memcached & drop-ins
+* Sanity checks for Memcached & drop-ins
 
 = 2.1.0 =
 * Refactor drop-ins

--- a/wp-spider-cache.php
+++ b/wp-spider-cache.php
@@ -38,7 +38,7 @@ class WP_Spider_Cache_UI {
 	 *
 	 * @var string
 	 */
-	private $asset_version = '201602160001';
+	private $asset_version = '201607130001';
 
 	/**
 	 * The resulting page's hook_suffix.


### PR DESCRIPTION
A few things are missing from the SVN version on plugins.wordpress - this would get it caught up to speed. I have a [draft tag ready to go](https://github.com/stuttter/wp-spider-cache/releases/tag/untagged-bf3cc9d4a69021ba9669) as well.

I am not sure of all the changes and just did a diff between the current tag and HEAD.
