### PR TITLE
Always cache headers as an array of header type

### DIFF
--- a/wp-spider-cache/includes/class-output-cache.php
+++ b/wp-spider-cache/includes/class-output-cache.php
@@ -330,7 +330,7 @@ class WP_Spider_Cache_Output {
 		// PHP5 and higher (
 		foreach ( headers_list() as $header ) {
 			list( $k, $v ) = array_map( 'trim', explode( ':', $header, 2 ) );
-			$this->cache['headers'][ $k ] = $v;
+			$this->cache['headers'][ $k ][] = $v;
 		}
 
 		// Set uncached headers


### PR DESCRIPTION
This solution fixed #22 for me. It also solved issue that [prevented](https://github.com/stuttter/wp-spider-cache/blob/e59e2ca9bd4a522d1995b3b3fb09172c2c7373ec/wp-spider-cache/includes/class-output-cache.php#L489) debug data from adding to output (because it assumes that header of type is always array).