### PR TITLE
Do not instantiate engine if class not available

### DIFF
--- a/wp-spider-cache/includes/class-object-base.php
+++ b/wp-spider-cache/includes/class-object-base.php
@@ -262,6 +262,12 @@ class WP_Spider_Cache_Object_Base {
 	 * @since 2.2.0
 	 */
 	private function set_engine() {
+
+		// Bail if engine not found
+		if ( ! class_exists( $this->engine_class_name ) ) {
+			return;
+		}
+
 		$this->engine = new $this->engine_class_name;
 	}
 


### PR DESCRIPTION
While the `$daemon` is currently only instantiated if its class is available (usually `Memcached`), the `$engine` (usually `Memcache`) does not have such a check applied beforehand.

Several hosts only have the `Memcached` class available, so I suggest adding a similar check before the `Memcache` instantiation, especially since that class is mostly outdated in favor of `Memcached`. Another reason: Given that the plugin only uses `Memcache` for retrieving statistics (one of the few things `Memcache` supports while `Memcached` doesn't), there shouldn't be any significant problems - the only thing is that the inspection of the cache in the admin will not work properly.